### PR TITLE
chore: Update capacitor/core to fix white screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2503,9 +2503,9 @@
       }
     },
     "@capacitor/core": {
-      "version": "3.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.0.0-beta.1.tgz",
-      "integrity": "sha512-g6ZknoO/J74ojGh1KPZuwkXs/dwNPm0+r4oojyWZiCNjT2iOwK8j3gA1QWz405GBdDyKXTR3oloUcs2jJBnOyg==",
+      "version": "3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.0.0-beta.2.tgz",
+      "integrity": "sha512-BTYVh4LMTY9lnT1qMwyAg8ursJCQyLilhZO8Uw1GFdNFKPCrTKwabzzOCM02EzhxZJDLNCVpoBufdBRlgEzz9Q==",
       "requires": {
         "tslib": "^2.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@capacitor/android": "^2.4.3",
     "@capacitor/app": "^0.3.1",
     "@capacitor/camera": "^0.3.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/filesystem": "^0.3.1",
     "@capacitor/haptics": "^0.3.1",
     "@capacitor/ios": "^3.0.0-beta.2",


### PR DESCRIPTION
Avoid "StatusBar plugin is not implemented for iOS" error by updating capacitor/core to latest beta